### PR TITLE
Added OWASP DVWS project

### DIFF
--- a/_data/offline.json
+++ b/_data/offline.json
@@ -1236,5 +1236,20 @@
 		"author": "Dolev Farhi <dolev@lethalbit.com>, Connor McKinnon",
 		"notes": null,
 		"badge": "dolevf/Damn-Vulnerable-GraphQL-Application"
+	},
+	{
+		"url": "https://owasp.org/www-project-damn-vulnerable-web-sockets/",
+		"name": "OWASP Damn Vulnerable Web Sockets (DVWS)",
+		"technology": [
+			"PHP",
+			"HTML",
+			"Javascript",
+			"WebSockets"
+		],
+		"references": [
+		],
+		"author": "Abhineet Jayaraj (@xploresec)",
+		"notes": null,
+		"badge": "interference-security/DVWS"
 	}
 ]


### PR DESCRIPTION
OWASP Damn Vulnerable Web Sockets (DVWS) project addition

Damn Vulnerable Web Sockets (DVWS) is a deliberately vulnerable and insecure web application which works on web sockets for client-server communication. It is built on PHP with Ratchet and utilizes MySQL as backend database. DVWS has a number of functionalities which you commonly see in every other web application, they have been implemented in web sockets which is different from a typical web application communication. It allows users to test their web sockets testing skills, tools and scripts for web socket vulnerabilities. Web socket testing can be performed using popular tools such as OWASP ZAP and Burp Suite.