### PR TITLE
Fixed incorrect credentials for Zero Bank

### DIFF
--- a/_data/online.json
+++ b/_data/online.json
@@ -454,8 +454,8 @@
 		],
 		"references": [
 		],
-		"author": "Micro Focus (was HP/SpiDynamics)",
-		"notes": "(admin/admin)",
+		"author": "Micro Focus Fortify (was HP/SpiDynamics)",
+		"notes": "(username/password)",
 		"badge": null
 	},
 	{


### PR DESCRIPTION
The credentials for Zero Bank were incorrect.