### PR TITLE
Add DamnVulnerableInfrastructure (DVI)

### DIFF
--- a/_data/collection.json
+++ b/_data/collection.json
@@ -3496,5 +3496,32 @@
 			"Bootstrap"
 		],
 		"url": "https://yrprey.com"
+	},
+	{
+		"url": "https://github.com/LBartolini/DVI",
+		"name": "Damn Vulnerable Infrastructure (DVI)",
+		"collection": [
+			"offline"
+		],
+		"technology": [
+			"PHP",
+			"Java",
+			"MySQL",
+			"SCADA",
+			"Docker"
+		],
+		"references": [
+			{
+				"name": "guide",
+				"url": "https://github.com/LBartolini/DVI/blob/main/GUIDE.md"
+			},
+			{
+				"name": "download",
+				"url": "https://github.com/LBartolini/DVI"
+			}
+		],
+		"author": "Lorenzo Bartolini, Gabriele Costa",
+		"notes": "A fully simulated and self-hosted Damn Vulnerable Infrastructure with routers, subnetworks, Scada and many other vulnerable containers. It simulates an Energy Management System inside a University Campus.",
+		"badge": "LBartolini/DVI"
 	}
 ]


### PR DESCRIPTION
@gabriele-costa and I propose to add DamnVulnerableInfrastructure (DVI) ([https://github.com/LBartolini/DVI](https://github.com/LBartolini/DVI)). 
DVI is a fully simulated and self-hosted vulnerable infrastructure with routers, subnetworks, Scada and many other vulnerable containers. It simulates an Energy Management System inside a University Campus. The repository contains instructions to install and deploy. A full Guide is also inside the repository. It has a strong story telling background with instructions, objectives and solutions.