### PR TITLE
Add InjuredAndroid project to collection.json

### DIFF
--- a/_data/collection.json
+++ b/_data/collection.json
@@ -3693,23 +3693,23 @@
 		"badge": "dineshshetty/Android-InsecureBankv2"
 	},
 	{
-	"url": "https://github.com/B3nac/InjuredAndroid",
-	"name": "InjuredAndroid",
-	"collection": [
-		"mobile"
-	],
-	"technology": [
-		"Android",
-		"Java"
-	],
-	"references": [
-		{
-			"name": "download",
-			"url": "https://github.com/B3nac/InjuredAndroid/releases"
-		}
-	],
-	"author": "B3nac",
-	"notes": "A vulnerable Android application with CTF-style challenges focused on Android security.",
-	"badge": "B3nac/InjuredAndroid"
+		"url": "https://github.com/B3nac/InjuredAndroid",
+		"name": "InjuredAndroid",
+		"collection": [
+			"mobile"
+		],
+		"technology": [
+			"Android",
+			"Java"
+		],
+		"references": [
+			{
+				"name": "download",
+				"url": "https://github.com/B3nac/InjuredAndroid/releases"
+			}
+		],
+		"author": "B3nac",
+		"notes": "A vulnerable Android application with CTF-style challenges focused on Android security.",
+		"badge": "B3nac/InjuredAndroid"
 	}
 ]


### PR DESCRIPTION
This PR adds **InjuredAndroid** to the mobile section of the OWASP Vulnerable Web Applications Directory.

- Name: InjuredAndroid
- URL: https://github.com/B3nac/InjuredAndroid
- Purpose: CTF-style Android security challenges
- Features: Focused on Android vulnerabilities and hands-on learning
- References: Download link included

Placed at the end of the last collection.

JSON entry validated and follows repository schema.