### PR TITLE
Add TryHackMe entry to collection.json

### DIFF
--- a/_data/collection.json
+++ b/_data/collection.json
@@ -2887,6 +2887,24 @@
 		"last_contributed": "2020-09-07T06:22:06Z"
 	},
 	{
+		"url": "https://tryhackme.com",
+		"name": "TryHackMe",
+		"collection": [
+			"online"
+		],
+		"technology": [
+			"Various"
+		],
+		"references": [
+			{
+				"name": "live",
+				"url": "https://tryhackme.com"
+			}
+		],
+		"author": "TryHackMe",
+		"notes": "Online platform for learning cyber security through hands-on exercises and labs. Features virtual rooms with vulnerable machines and guided learning paths."
+	},
+	{
 		"url": "https://github.com/sakti/twitterlike",
 		"name": "twitterlike",
 		"collection": [


### PR DESCRIPTION
This PR adds **TryHackMe** to the online section of the OWASP Vulnerable Web Applications Directory.

- Name: TryHackMe
- URL: https://tryhackme.com
- Purpose: Online cyber security learning platform with hands-on labs
- Features: Virtual rooms, vulnerable machines, guided learning paths
- References: Live platform link included

Placed at the end of the last collection.
JSON entry validated and follows repository schema.