### PR TITLE
Fix CI schema validation by explicitly enabling JSON Schema Draft 2020-12

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,7 @@ jobs:
          npm install -g ajv-cli
     - name: Run schema check
       run: |
-        ajv validate \--spec=draft2020 \-s schema.json \-d _data/collection.json \--all-errors \--errors=text \--verbose=true \-c=ajv-formats \1>> log.txt 2>&1
+        ajv validate --spec=draft2020 -s schema.json -d _data/collection.json --all-errors --errors=text --verbose=true -c=ajv-formats 1>> log.txt 2>&1
     - name: Show Validation Issues
       if: failure()
       run: cat log.txt


### PR DESCRIPTION
Proposed change
This PR fixes #197  the CI schema validation failure by explicitly specifying the JSON Schema dialect used during validation.
The schema.json file declares the Draft 2020-12 dialect via the $schema field. However, ajv-cli does not automatically infer the dialect from this declaration and defaults to an older draft unless explicitly instructed.
To align the CI validation process with the schema definition, this PR updates the ajv validate command to include:

--spec=draft2020

This ensures that schema validation is performed using the correct JSON Schema specification and prevents false validation errors.