### PR TITLE
Restore commit badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ ordering_log.txt
 editorconfig_log.txt
 artifact.txt
 pr_number
+
+# Misc
+sort_json.py
+.ruby-version

--- a/_includes/collection_table.html
+++ b/_includes/collection_table.html
@@ -61,16 +61,19 @@
     <td>
       {% if app.technology %}
         <ul>
-          {% for tech in app.technology %}
+          {%- for tech in app.technology -%}
             <li>{{ tech }}</li>
-          {% endfor %}
+          {%- endfor -%}
         </ul>
       {% endif %}
     </td>
     <td data-sort-value-text="{{ app.notes | default: '' }}" data-sort-value-date="{{ app.last_contributed | default: '' }}">
         {{ app.notes }}
         {% if app.last_contributed %}
-            <br><small>Last commit: {{ app.last_contributed | date: "%Y-%m-%d" }}</small>
+            <br><small class="not-displayed">Last commit: {{ app.last_contributed | date: "%Y-%m-%d" }}</small>
+        {% endif %}
+        {% if app.badge %}
+             <img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/{{ app.badge }}">
         {% endif %}
     </td>
   </tr>

--- a/assets/css/collection_table.css
+++ b/assets/css/collection_table.css
@@ -1,4 +1,7 @@
-ul { padding: 5px; }
+ul { 
+  padding: 5px;
+  margin: 0px;
+}
 
 .collection-table-wrapper table li {
   margin-left: 10px !important;
@@ -113,6 +116,9 @@ tr.filtered-out {
   display: none;
 }
 
+small.not-displayed {
+  display:none;
+}
 
 .collection-table-wrapper {
   display: block !important;


### PR DESCRIPTION
- Make the last commit date hidden (so that it can still be used for sorting functionality)
- Restore shields.io last commit badges for visual appeal
- Remove margin from UL (it was being calculated as 16pw and forcing lists down vertically within table cells)
- Tweak .gitignore for current dev realities
