### PR TITLE
Implement deduplication of multi-option inputs in Advanced Search

### DIFF
--- a/assets/js/advanced_search/index.js
+++ b/assets/js/advanced_search/index.js
@@ -223,6 +223,23 @@
     closeModalAndDiscard(modal);
   }
 
+  function dedupeMultiOptions(modal) {
+    if (!modal) return;
+    const seen = new Set();
+    modal.querySelectorAll('[data-multi-option]').forEach(input => {
+      const type = input.getAttribute('data-multi-option') || '';
+      const value = (input.value || '').trim().toLowerCase();
+      const key = `${type}:${value}`;
+      if (!value) return;
+      if (seen.has(key)) {
+        const option = input.closest('.multi-option');
+        if (option) option.remove();
+        return;
+      }
+      seen.add(key);
+    });
+  }
+
   function initModal(modal) {
     if (modal.dataset.advancedInit === '1') return;
     modal.dataset.advancedInit = '1';
@@ -231,6 +248,8 @@
     const searchInput = modal.querySelector('.advanced-search-input');
     const clearButton = modal.querySelector('.advanced-clear');
     const acceptButton = modal.querySelector('.advanced-accept');
+
+    dedupeMultiOptions(modal);
 
     CollectionTable.registerAdvancedSync(collection, (state) => {
       const draft = getDraft(collection);


### PR DESCRIPTION
Fixes a bug in the Advanced Search modal where duplicate filter options with different casing are treated as separate values. We now de‑duplicate multi‑select options by case, preserving the first label. Example: in the Offline collection, “.Net” and “.NET” previously appeared as separate Technology options and caused duplicate pills / inconsistent filter behavior.