### PR TITLE
Normalize tech labels and dedupe dropdowns with canonical names

### DIFF
--- a/_data/collection.json
+++ b/_data/collection.json
@@ -285,7 +285,7 @@
 			"online"
 		],
 		"technology": [
-			"react",
+			"React",
 			"Node",
 			"Swagger"
 		],

--- a/_data/dedupe-list.json
+++ b/_data/dedupe-list.json
@@ -1,0 +1,11 @@
+[
+  { "canonical": "Node.js", "aliases": ["Node", "NodeJS", "node.js", "Node js"] },
+  { "canonical": ".NET", "aliases": [".Net", ".net"] },
+  { "canonical": "Express", "aliases": ["Expressjs", "Express.js"] },
+  { "canonical": "Next.js", "aliases": ["Nextjs", "Next JS", "NextJS", "next.js"] },
+  { "canonical": "Angular", "aliases": ["Angular.js", "Angularjs"] },
+  { "canonical": "PostgreSQL", "aliases": ["Postgres", "Postgresql"] },
+  { "canonical": "WebSockets", "aliases": ["web sockets", "Websockets", "websockets"] },
+  { "canonical": "REST API", "aliases": ["Rest", "Rest API", "Restapi"] },
+  { "canonical": "OpenAPI", "aliases": ["Swagger", "Open API", "Swagger/OpenAPI"] }
+]

--- a/_includes/collection_table/advanced_search.html
+++ b/_includes/collection_table/advanced_search.html
@@ -1,11 +1,22 @@
 {% assign tech_options = "" | split: "," %}
+{% assign tech_seen = "" | split: "," %}
 {% assign ref_options = "" | split: "," %}
 {% assign year_options = "" | split: "," %}
 
 {% for app in include.apps %}
   {% if app.technology %}
     {% for tech in app.technology %}
-      {% assign tech_options = tech_options | push: tech %}
+      {% capture canonical_tech %}
+        {% include collection_table/normalize_value.html value=tech %}
+      {% endcapture %}
+      {% assign canonical_tech = canonical_tech | strip %}
+      {% if canonical_tech != "" %}
+        {% assign canonical_tech_lc = canonical_tech | downcase %}
+        {% unless tech_seen contains canonical_tech_lc %}
+          {% assign tech_seen = tech_seen | push: canonical_tech_lc %}
+          {% assign tech_options = tech_options | push: canonical_tech %}
+        {% endunless %}
+      {% endif %}
     {% endfor %}
   {% endif %}
 

--- a/_includes/collection_table/normalize_value.html
+++ b/_includes/collection_table/normalize_value.html
@@ -1,0 +1,23 @@
+{%- assign input_value = include.value | default: '' -%}
+{%- assign normalized_value = input_value -%}
+{%- assign input_lc = input_value | downcase -%}
+{%- assign matched = false -%}
+{%- for entry in site.data["dedupe-list"] -%}
+  {%- if matched -%}{% break %}{%- endif -%}
+  {%- assign canonical = entry.canonical | default: '' -%}
+  {%- assign canonical_lc = canonical | downcase -%}
+  {%- if input_lc == canonical_lc -%}
+    {%- assign normalized_value = canonical -%}
+    {%- assign matched = true -%}
+    {%- break -%}
+  {%- endif -%}
+  {%- for alias in entry.aliases -%}
+    {%- assign alias_lc = alias | downcase -%}
+    {%- if input_lc == alias_lc -%}
+      {%- assign normalized_value = canonical -%}
+      {%- assign matched = true -%}
+      {%- break -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
+{{- normalized_value -}}

--- a/_includes/collection_table/scripts.html
+++ b/_includes/collection_table/scripts.html
@@ -1,3 +1,11 @@
+{% unless dedupe_map_included %}
+  {% assign dedupe_map_included = true %}
+  <!-- Optional runtime mapping for future use; build-time normalization uses _data/dedupe-list.json. -->
+  <script type="application/json" data-dedupe-map>
+    {{ site.data["dedupe-list"] | jsonify }}
+  </script>
+{% endunless %}
+
 <script src="{{ '/assets/js/collection_table/utils.js?v=2026-01-09' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/collection_table/state.js?v=2026-01-09' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/collection_table/sorting.js?v=2026-01-09' | relative_url }}" defer></script>

--- a/_includes/collection_table/table.html
+++ b/_includes/collection_table/table.html
@@ -16,10 +16,24 @@
     {% endif %}
   </tr>
   {% for app in include.apps %}
-  {% assign tech_values = "" %}
+  {% assign tech_values = "" | split: "," %}
+  {% assign tech_seen = "" | split: "," %}
   {% if app.technology %}
-    {% assign tech_values = app.technology | join: "|" | downcase %}
+    {% for tech in app.technology %}
+      {% capture canonical_tech %}
+        {% include collection_table/normalize_value.html value=tech %}
+      {% endcapture %}
+      {% assign canonical_tech = canonical_tech | strip %}
+      {% if canonical_tech != "" %}
+        {% assign canonical_tech_lc = canonical_tech | downcase %}
+        {% unless tech_seen contains canonical_tech_lc %}
+          {% assign tech_seen = tech_seen | push: canonical_tech_lc %}
+          {% assign tech_values = tech_values | push: canonical_tech %}
+        {% endunless %}
+      {% endif %}
+    {% endfor %}
   {% endif %}
+  {% assign tech_filter_values = tech_values | join: "|" | downcase %}
   {% assign ref_values = "" %}
   {% if app.references %}
     {% assign ref_values = app.references | map: "name" | join: "|" | downcase %}
@@ -28,7 +42,7 @@
   {% if app.last_contributed %}
     {% assign year_value = app.last_contributed | date: "%Y" %}
   {% endif %}
-  <tr data-filter-tech="{{ tech_values | escape }}" data-filter-refs="{{ ref_values | escape }}" data-filter-stars="{{ app.stars | default: 0 }}" data-filter-year="{{ year_value }}">
+  <tr data-filter-tech="{{ tech_filter_values | escape }}" data-filter-refs="{{ ref_values | escape }}" data-filter-stars="{{ app.stars | default: 0 }}" data-filter-year="{{ year_value }}">
     <td data-sort-value-text="{{ app.name | default: '' }}" data-sort-value-numeric="{{ app.stars | default: 0 }}">
         <a href="{{ app.url }}">{{ app.name }}</a>
         {% if app.stars %}
@@ -48,9 +62,9 @@
       {% endif %}
     </td>
     <td>
-      {% if app.technology %}
+      {% if tech_values.size > 0 %}
         <ul>
-          {%- for tech in app.technology -%}
+          {%- for tech in tech_values -%}
             <li>{{ tech }}</li>
           {%- endfor -%}
         </ul>


### PR DESCRIPTION
## Summary

There are repeated tech entries in `collection.json` that are the same technology but spelled slightly differently like NodeJS or Node.js (not necessarily typos). Those variants were treated as separate options in Advanced Search, which caused duplicate yet separate search parameters and odd filter behavior even though the filter logic lowercases values.

This PR introduces a canonical mapping for `Technology(ies)` entries in `collection.json` so common variants collapse into one label and is used in both the Advanced Search dropdowns *and* in the Collection Table content display directly. It's a more proactive, frictionless approach than expecting contributors adding entries to know which exact spelling to always use for a term (and thereby preventing small variations to create duplicate search options). It also makes entries in the table read more consistently.

Live demo available at: [vwad.ritovision.com](https://vwad.ritovision.com)

## What changed

- Added `_data/dedupe-list.json` as a canonical map (`canonical` + `aliases`).
- Added `_includes/collection_table/normalize_value.html` to normalize tech labels at build time.
- Advanced Search tech options and table tech lists now normalize + case‑dedupe using the canonical map.
- Existing lowercase normalization still applies for matching; canonical mapping controls display/option uniqueness.
- Optional runtime JSON embed is included in `_includes/collection_table/scripts.html` for future JS usage (not required for current behavior).

## How to use
Add a canonical name to `_data/dedupe-list.json` and list aliases that should collapse into that canonical name. This currently applies to `Technology(ies)` values only; all instances render as the canonical label in the table and Advanced Search.

## Example variants now normalized

- `.NET`, `Node.js`, `Express`, `Angular`, `PostgreSQL`, `REST API`, `OpenAPI`, `Next.js`, `WebSockets`

## Notes

- Lowercase normalization still powers the filter matching.
- Canonical mapping ensures the UI only shows one consistent label for each tech in the Technology(ies) category of `collection.json`.
- The optional JSON embed is for future client‑side use; current behavior is build‑time normalization via Liquid.
