### PR TITLE
Add URL pattern validation to schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -52,7 +52,8 @@
 			"properties": {
 				"url": {
 					"type": "string",
-					"format": "uri"
+					"format": "uri",
+					"pattern": "^https?://.*"
 				},
 				"name": {
 					"type": "string"
@@ -117,7 +118,8 @@
 				},
 				"url": {
 					"type": "string",
-					"format": "uri"
+					"format": "uri",
+					"pattern": "^https?://.*"
 				}
 			},
 			"required": [


### PR DESCRIPTION
Added a pattern validation for the 'url' properties to ensure they starts with 'http://' or 'https://'.

Per: https://github.com/OWASP/www-project-vulnerable-web-applications-directory/pull/240