### PR TITLE
Update archive check to keep history & create issue

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -16,13 +16,13 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request_target' }}
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           name: artifact
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Comment on PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/repo-scout.yml
+++ b/.github/workflows/repo-scout.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       
@@ -35,7 +35,7 @@ jobs:
       
       - name: Create Issue with Findings
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   update-stats:
@@ -18,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       
@@ -36,18 +37,45 @@ jobs:
       - name: Check for changes
         id: git-check
         run: |
-          git diff --exit-code _data/collection.json || echo "changed=true" >> $GITHUB_OUTPUT
+          if [ -n "$(git status --short _data/collection.json _data/archived_repos.json 2>/dev/null)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
       
       - name: Commit and push if changed
         if: steps.git-check.outputs.changed == 'true'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add _data/collection.json
+          git add _data/collection.json _data/archived_repos.json
           git commit -m "Update GitHub statistics [automated]"
           git push
       
       - name: No changes detected
         if: steps.git-check.outputs.changed != 'true'
         run: |
-          echo "No changes to collection.json"
+          echo "No changes to collection.json or archived repos list"
+
+      - name: Create issue for archived repositories
+        if: success() && hashFiles('archived_repos.json') != ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('archived_repos.json')) {
+              console.log('No archived repositories');
+              return;
+            }
+            const data = JSON.parse(fs.readFileSync('archived_repos.json', 'utf8'));
+            if (!data.archived_repos || data.archived_repos.length === 0) {
+              console.log('No archived repositories');
+              return;
+            }
+            const issueBody = fs.readFileSync('archived-repos-issue-body.md', 'utf8');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `📦 Archived repositories in directory (${data.run_date})`,
+              body: issueBody,
+              labels: ['archived-repo']
+            });
+            console.log(`Created issue for ${data.archived_repos.length} archived repository(ies)`);

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ pr_number
 # GitHub stats cache
 .github_stats_cache.json
 
+# Update-stats workflow artifacts (archived repos issue)
+archived_repos.json
+archived-repos-issue-body.md
+
 # Misc
 sort_json.py
 .ruby-version


### PR DESCRIPTION
- **Archived repos:** Update-stats workflow now creates a GitHub issue when newly archived repositories are found. Script writes entries with full URL, date, and notes.
- **Persistent list:** `_data/archived_repos.json` records archived repos we’re tracking; already-listed repos do not get another issue. Notes can mark “keeping” or similar.
- **Workflow commits:** Workflow commits and pushes `_data/collection.json` and `_data/archived_repos.json` when either changes.
- **Actions pinned by SHA:** Workflows use full commit SHAs for actions, with version in a comment (e.g. `actions/checkout@<sha>  # v6`) so Dependabot can update them safely.