### PR TITLE
Add Jackpot, a browser lab for the OWASP LLM Top 10

### DIFF
--- a/_data/collection.json
+++ b/_data/collection.json
@@ -2263,6 +2263,30 @@
 		]
 	},
 	{
+		"url": "https://hego.red/jackpot",
+		"name": "Jackpot",
+		"collection": [
+			"online"
+		],
+		"technology": [
+			"AI",
+			"LLM",
+			"Prompt Injection"
+		],
+		"references": [
+			{
+				"name": "live",
+				"url": "https://hego.red/jackpot"
+			}
+		],
+		"author": "hego",
+		"description": "A ten floor casino where every floor is a deliberately broken AI character, one per category of the OWASP Top 10 for LLM Applications. Covers prompt injection, system prompt leakage, RAG poisoning, excessive agency and improper output handling. Runs in the browser, no signup.",
+		"categories": [
+			"ctf",
+			"single-player"
+		]
+	},
+	{
 		"url": "https://github.com/Sjord/jwtdemo/",
 		"name": "jwtdemo",
 		"collection": [


### PR DESCRIPTION
Adds **Jackpot** (https://hego.red/jackpot), a free browser based lab where each of ten floors is a deliberately vulnerable AI character mapped to one category of the OWASP Top 10 for LLM Applications.

- Online, no signup, no accounts, nothing stored server side
- Ten floors: LLM01 through LLM10, so prompt injection, system prompt leakage, RAG poisoning, excessive agency, improper output handling and the rest
- The characters are a deterministic simulation rather than a live model, so it is free to run, needs no API key and grades identically for everyone
- Win conditions, trigger lists and the secrets are server side only, so the answers are not in the page
- Every floor wins on a fact (the secret left the model, the tool fired), never on a guess about intent

Entry added to `_data/collection.json`, tab indented and sorted case insensitively by `name` (between `InsecureBankv2` and `jwtdemo`). The file still parses and the rest of it is untouched.

Disclosure: I am the author.
